### PR TITLE
UX: use group full name, add settings for description & ordering

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,9 +1,28 @@
 .about__main-content {
   .--custom-group {
     margin-top: 3em;
-    @if $capitalize-names == "true" {
+    h3 {
+      a {
+        color: var(--primary);
+        &:hover {
+          color: var(--tertiary);
+        }
+      }
+      @if $capitalize-names == "true" {
+        &:first-letter {
+          text-transform: capitalize;
+        }
+      }
+    }
+
+    p {
+      margin-top: 0;
+      color: var(--primary-high);
+    }
+
+    &.--has-description {
       h3 {
-        text-transform: capitalize;
+        margin-bottom: 0;
       }
     }
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,5 +1,6 @@
 .about__main-content {
   .--custom-group {
+    max-width: unset !important; // ovverides ridiculously specific core style
     margin-top: 3em;
     h3 {
       a {

--- a/common/common.scss
+++ b/common/common.scss
@@ -10,7 +10,7 @@
         }
       }
       @if $capitalize-names == "true" {
-        &:first-letter {
+        &::first-letter {
           text-transform: capitalize;
         }
       }

--- a/javascripts/discourse/components/additional-about-groups.gjs
+++ b/javascripts/discourse/components/additional-about-groups.gjs
@@ -5,6 +5,7 @@ import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
 import AboutPageUsers from "discourse/components/about-page-users";
 import ConditionalLoadingSpinner from "discourse/components/conditional-loading-spinner";
+import { ajax } from "discourse/lib/ajax";
 
 export default class AdditionalAboutGroups extends Component {
   @service store;
@@ -75,9 +76,8 @@ export default class AdditionalAboutGroups extends Component {
 
   async loadGroupDetails(groupName) {
     try {
-      const response = await fetch(`/g/${groupName}.json`);
-      const data = await response.json();
-      return data.group;
+      const response = await ajax(`/g/${groupName}`);
+      return response.group;
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(`Error loading details for group ${groupName}:`, error);
@@ -87,9 +87,8 @@ export default class AdditionalAboutGroups extends Component {
 
   async loadGroupMembers(groupName) {
     try {
-      const response = await fetch(`/g/${groupName}/members.json`);
-      const data = await response.json();
-      return data.members || [];
+      const response = await ajax(`/g/${groupName}/members`);
+      return response.members || [];
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(`Error loading members for group ${groupName}:`, error);

--- a/javascripts/discourse/components/additional-about-groups.gjs
+++ b/javascripts/discourse/components/additional-about-groups.gjs
@@ -88,7 +88,7 @@ export default class AdditionalAboutGroups extends Component {
   async loadGroupMembers(groupName) {
     try {
       const response = await fetch(
-        `/g/${groupName}/members.json?offset=0&order=&asc=true`
+        `/g/${groupName}/members.json`
       );
       const data = await response.json();
       return data.members || [];

--- a/javascripts/discourse/components/additional-about-groups.gjs
+++ b/javascripts/discourse/components/additional-about-groups.gjs
@@ -87,9 +87,7 @@ export default class AdditionalAboutGroups extends Component {
 
   async loadGroupMembers(groupName) {
     try {
-      const response = await fetch(
-        `/g/${groupName}/members.json`
-      );
+      const response = await fetch(`/g/${groupName}/members.json`);
       const data = await response.json();
       return data.members || [];
     } catch (error) {

--- a/javascripts/discourse/components/additional-about-groups.gjs
+++ b/javascripts/discourse/components/additional-about-groups.gjs
@@ -102,7 +102,7 @@ export default class AdditionalAboutGroups extends Component {
   <template>
     <ConditionalLoadingSpinner @condition={{this.loading}}>
       {{#if this.groups}}
-        {{#each this.groups as |group|}}{{log group}}
+        {{#each this.groups as |group|}}
           <section
             class="about__{{group.name}}
               --custom-group

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,3 +5,5 @@ en:
       about_groups: "Groups to show on the about page, groups with 0 members are automatically hidden."
       show_initial_members: "Number of members to show on initial load for each group, others will be hidden behing a 'show more' button."
       capitalize_names: "Capitalize the names of the groups on the about page."
+      order_additional_groups: "Reorder the groups added by this theme component. Note: won't change the order of default admin and moderator groups."
+      show_group_description: "Show the group description on the about page."

--- a/settings.yml
+++ b/settings.yml
@@ -10,3 +10,15 @@ show_initial_members:
 capitalize_names:
   default: true
   type: bool
+
+order_additional_groups:
+  default: "alphabetically"
+  type: enum
+  choices:
+    - "alphabetically"
+    - "order of creation"
+    - "order of theme setting"
+
+show_group_description:
+  default: true
+  type: bool

--- a/settings.yml
+++ b/settings.yml
@@ -20,5 +20,5 @@ order_additional_groups:
     - "order of theme setting"
 
 show_group_description:
-  default: true
+  default: false
   type: bool

--- a/spec/system/add_groups_to_about_spec.rb
+++ b/spec/system/add_groups_to_about_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Additional About Groups", type: :system do
   it "renders the groups specified in the about_groups theme setting" do
     visit "/about"
 
-    expect(about_groups_component).to have_group_with_name("Group1")
-    expect(about_groups_component).to have_group_with_name("Group2")
+    expect(about_groups_component).to have_group_with_name("group1")
+    expect(about_groups_component).to have_group_with_name("group2")
     expect(about_groups_component).to have_group_with_member("user1")
     expect(about_groups_component).to have_group_with_member("user2")
   end
@@ -30,8 +30,8 @@ RSpec.describe "Additional About Groups", type: :system do
 
     visit "/about"
 
-    expect(about_groups_component).to have_group_with_name("Group1")
-    expect(about_groups_component).to have_no_group_with_name("Group2")
+    expect(about_groups_component).to have_group_with_name("group1")
+    expect(about_groups_component).to have_no_group_with_name("group2")
     expect(about_groups_component).to have_group_with_member("user1")
     expect(about_groups_component).to have_no_group_with_member("user2")
   end


### PR DESCRIPTION
Adds an additional request to get the full name, and optional settings for showing the group description and changing the group order. 

![image](https://github.com/user-attachments/assets/44b516a7-c75d-4d86-9c0e-7ee523d7428e)
