### PR TITLE
UX: order members in ascending order alphabetically

### DIFF
--- a/javascripts/discourse/components/additional-about-groups.gjs
+++ b/javascripts/discourse/components/additional-about-groups.gjs
@@ -87,7 +87,7 @@ export default class AdditionalAboutGroups extends Component {
 
   async loadGroupMembers(groupName) {
     try {
-      const response = await ajax(`/g/${groupName}/members`);
+      const response = await ajax(`/g/${groupName}/members?asc=true`);
       return response.members || [];
     } catch (error) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
without `?asc=true` members are ordered by username in reverse alphabetical order, which doesn't make much sense 