### PR TITLE
DEV: Add a flag to facilitate merging into core

### DIFF
--- a/javascripts/discourse/api-initializers/add-groups-to-about.js
+++ b/javascripts/discourse/api-initializers/add-groups-to-about.js
@@ -2,5 +2,12 @@ import { apiInitializer } from "discourse/lib/api";
 import AdditionalAboutGroups from "../components/additional-about-groups";
 
 export default apiInitializer("1.14.0", (api) => {
+  const siteSettings = api.container.lookup("service:site-settings");
+
+  // Functionality is moving into core.
+  if (siteSettings.show_additional_about_groups === true) {
+    return;
+  }
+
   api.renderInOutlet("about-after-moderators", AdditionalAboutGroups);
 });

--- a/spec/system/add_groups_to_about_spec.rb
+++ b/spec/system/add_groups_to_about_spec.rb
@@ -15,11 +15,19 @@ RSpec.describe "Additional About Groups", type: :system do
     theme.save!
   end
 
+  it "does not render extra groups when the feature is enabled in core" do
+    SiteSetting.show_additional_about_groups = true
+
+    visit "/about"
+
+    expect(about_groups_component).to have_no_group_with_name("Group1")
+  end
+
   it "renders the groups specified in the about_groups theme setting" do
     visit "/about"
 
-    expect(about_groups_component).to have_group_with_name("group1")
-    expect(about_groups_component).to have_group_with_name("group2")
+    expect(about_groups_component).to have_group_with_name("Group1")
+    expect(about_groups_component).to have_group_with_name("Group2")
     expect(about_groups_component).to have_group_with_member("user1")
     expect(about_groups_component).to have_group_with_member("user2")
   end
@@ -30,8 +38,8 @@ RSpec.describe "Additional About Groups", type: :system do
 
     visit "/about"
 
-    expect(about_groups_component).to have_group_with_name("group1")
-    expect(about_groups_component).to have_no_group_with_name("group2")
+    expect(about_groups_component).to have_group_with_name("Group1")
+    expect(about_groups_component).to have_no_group_with_name("Group2")
     expect(about_groups_component).to have_group_with_member("user1")
     expect(about_groups_component).to have_no_group_with_member("user2")
   end

--- a/spec/system/page_objects/components/additional_about_groups.rb
+++ b/spec/system/page_objects/components/additional_about_groups.rb
@@ -8,7 +8,7 @@ module PageObjects
       end
 
       def has_no_group_with_name?(name)
-        has_no_css?(".about__#{name} h3", text: name)
+        has_no_css?(".about__#{name.downcase} h3", text: name)
       end
 
       def has_group_with_member?(username)


### PR DESCRIPTION
### What is this change?

We're merging the functionality of this theme component into core. As per protocol we need a site setting to facilitate the switchover.

See: https://github.com/discourse/discourse/pull/32657