### PR TITLE
UX: only show global deprecation notice to staff

### DIFF
--- a/javascripts/discourse/api-initializers/add-groups-to-about.js
+++ b/javascripts/discourse/api-initializers/add-groups-to-about.js
@@ -4,16 +4,19 @@ import AdditionalAboutGroups from "../components/additional-about-groups";
 
 export default apiInitializer("1.14.0", (api) => {
   const siteSettings = api.container.lookup("service:site-settings");
+  const currentUser = api.container.lookup("service:current-user");
 
-  addGlobalNotice(
-    `<b>Admin notice:</b> you're using the <em>discourse-add-groups-to-about</em> theme component. This feature is now available in Discourse core. You should remove this theme component.`,
-    "add-groups-to-about-component",
-    {
-      dismissable: true,
-      level: "warn",
-      dismissDuration: moment.duration("1", "hour"),
-    }
-  );
+  if (currentUser?.staff) {
+    addGlobalNotice(
+      `<b>Admin notice:</b> you're using the <em>discourse-add-groups-to-about</em> theme component. This feature is now available in Discourse core. You should remove this theme component.`,
+      "add-groups-to-about-component",
+      {
+        dismissable: true,
+        level: "warn",
+        dismissDuration: moment.duration("1", "hour"),
+      }
+    );
+  }
 
   // Functionality is moving into core.
   if (siteSettings.show_additional_about_groups === true) {


### PR DESCRIPTION
This notice shouldn't appear for all users, only staff — reported here https://meta.discourse.org/t/additional-groups-not-visible-on-about-page/368218/11?u=awesomerobot